### PR TITLE
Fix `moduleSafeName` getter in `options` object

### DIFF
--- a/slushfile.js
+++ b/slushfile.js
@@ -7,21 +7,16 @@ const _ = require('lodash');
 const fs = require('fs');
 const execS = require('child_process').execSync;
 
-const GetSafeName = {
-	get moduleSafeName() {
-		return this.moduleNaturalName.replace(' ', '-');
-	},
-};
+const defaults = {
+  moduleNaturalName: process.argv[3] || 'htz-',
+  moduleDescription: '',
+  moduleAuthorName: execS('git config user.name', { encoding: 'utf8' }).split('\n')[0],
+  moduleAuthorEmail: execS('git config user.email', { encoding: 'utf8' }).split('\n')[0],
 
-const defaults = Object.assign(
-  Object.create(GetSafeName),
-  {
-    moduleNaturalName: process.argv[3] || 'htz-',
-    moduleDescription: '',
-    moduleAuthorName: execS('git config user.name', { encoding: 'utf8' }).split('\n')[0],
-    moduleAuthorEmail: execS('git config user.email', { encoding: 'utf8' }).split('\n')[0]
-  }
-);
+  get moduleSafeName() {
+    return this.moduleNaturalName.replace(' ', '-');
+  },
+};
 
 // const textTransform = textTransformation(transformString);
 
@@ -40,12 +35,12 @@ gulp.task('default', function (done) {
 			delete (answers.moveon);
 
       const options = Object.assign(
-        Object.create(GetSafeName),
-        defaults,
+        Object.create(defaults),
         answers
       );
 
 			const targetFolder = path.join(process.cwd(), options.moduleSafeName);
+
 			gulp.src(__dirname + '/template/**', { dot: true })  // Note use of __dirname to be relative to generator
 				.pipe(template(options))                           // Lodash template support
 				.pipe(conflict(targetFolder))                      // Confirms overwrites on file conflicts

--- a/slushfile.js
+++ b/slushfile.js
@@ -1,11 +1,11 @@
-const gulp = require('gulp'),
-	conflict = require('gulp-conflict'),
-	template = require('gulp-template'),
-	path = require('path'),
-	inquirer = require('inquirer'),
-	_ = require('lodash'),
-	fs = require('fs'),
-	execS = require('child_process').execSync;
+const gulp = require('gulp');
+const conflict = require('gulp-conflict');
+const template = require('gulp-template');
+const path = require('path');
+const inquirer = require('inquirer');
+const _ = require('lodash');
+const fs = require('fs');
+const execS = require('child_process').execSync;
 
 const defaults = {
 	moduleNaturalName: process.argv[3] || 'htz-',
@@ -32,7 +32,14 @@ gulp.task('default', function (done) {
 				return done();
 			}
 			delete (answers.moveon);
-			let options = _.defaults(answers, defaults);
+			const options = _.defaults(answers, defaults);
+
+      Object.defineProperty(options, 'moduleSafeName', {
+        get: function () {
+          return this.moduleNaturalName.replace(' ', '-');
+        }
+      });
+
 			const targetFolder = path.join(process.cwd(), options.moduleSafeName);
 			gulp.src(__dirname + '/template/**', { dot: true })  // Note use of __dirname to be relative to generator
 				.pipe(template(options))                 // Lodash template support


### PR DESCRIPTION
The getter always referred to the `defaults` object, so `moduleSafeName` 
was only correctly set if passed as a commandline argument.