### PR TITLE
Add `ts-node` as a devDependency when using ts

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -131,6 +131,7 @@
     "typescript": "^2.2.0",
     "awesome-typescript-loader": "3.0.3",
     "tslib": "1.5.0",
+    "ts-node": "^2.1.0",
     <% } %>
     <% if (typescript && lint) {%>
     "tslint": "^4.4.2",


### PR DESCRIPTION
`ts-node` is required for `nyc` to generate coverage reports.